### PR TITLE
remove bad example from config.yml, dataset check occurs from table spec

### DIFF
--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -20,11 +20,6 @@ runner: dataflow
 # [required] source: The source in format [PROJECT]:[DATASET] for dataset or [PROJECT]:[DATASET].[TABLE] for table
 # [required] target: The target in format [PROJECT]:[DATASET] for dataset or [PROJECT]:[DATASET].[TABLE] for table
 copies:
-# Dataset copy
-- source: bigquery-public-data:world_bank_wdi
-  target: <YOUR_PROJECT_ID>:world_bank_wdi
-  numWorkers: 2
-  maxNumWorkers: 2
 
 # Table copy to EU
 - source: bigquery-public-data:world_bank_wdi.country_series_definitions


### PR DESCRIPTION
Datasets are created at table creation time if it doesn't exist and the `targetDataSetLocation` field is defined.

thanks to [this](https://github.com/polleyg/gcp-dataflow-copy-bigquery/blob/master/src/main/java/org/polleyg/BQTableCopyPipeline.java#L261) block

Removing unneeded block defining dataset explicitly for copy.
