### PR TITLE
Allow the use of GCS hosting for table/dataset config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ service, or simply give it the `Project Editor` role if you're comfortable with 
  3A. Clone the GitHub repo and make the necessary changes to `config.yaml`  
  4A. Finally, `gcloud builds submit --config=cloudbuild.yaml <path_to_repo>`  
   
-####Option B: Provide config in GCS
+####Option B: Provide config in GCS (CloudBuild must have access to this file)
  3B. Pull the GitHub repo  
  4B. Upload your config to GCS `gs://bucket/containing/my/config.yaml`   
- 5B. Finally, `gcloud builds submit --config=cloudbuild.yaml --substitutions=_ARGS='--configPath=gs://bucket/containing/my/config.yaml' <path_to_repo>`   
+ 5B. Finally, ` gcloud builds submit --config=cloudbuild.yaml --substitutions=_APP_ARGS=--configPath=gs://bucket/containing/my/config.yaml  
   
 
 ## Any known limitations?

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ service, or simply give it the `Project Editor` role if you're comfortable with 
 #### Option B: Provide config in GCS (CloudBuild must have access to this file)
  3B. Pull the GitHub repo  
  4B. Upload your config to GCS `gs://bucket/containing/my/config.yaml`   
- 5B. Finally, ` gcloud builds submit --config=cloudbuild.yaml --substitutions=_APP_ARGS=--configPath=gs://bucket/containing/my/config.yaml  
+ 5B. Finally, `gcloud builds submit --config=cloudbuild.yaml --substitutions=_APP_ARGS=--configPath=gs://bucket/containing/my/config.yaml`
   
 
 ## Any known limitations?

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ BigQuery, GCS, and Cloud Build.
 like `<your_project_number>@cloudbuild.gserviceaccount.com`. You can give it only the required permissions for each
 service, or simply give it the `Project Editor` role if you're comfortable with that.
 
-####Option A: Clone and Source control your config
+#### Option A: Clone and Source control your config
  3A. Clone the GitHub repo and make the necessary changes to `config.yaml`  
  4A. Finally, `gcloud builds submit --config=cloudbuild.yaml <path_to_repo>`  
   
-####Option B: Provide config in GCS (CloudBuild must have access to this file)
+#### Option B: Provide config in GCS (CloudBuild must have access to this file)
  3B. Pull the GitHub repo  
  4B. Upload your config to GCS `gs://bucket/containing/my/config.yaml`   
  5B. Finally, ` gcloud builds submit --config=cloudbuild.yaml --substitutions=_APP_ARGS=--configPath=gs://bucket/containing/my/config.yaml  

--- a/README.md
+++ b/README.md
@@ -42,8 +42,16 @@ BigQuery, GCS, and Cloud Build.
  2. Elevate permissions on the Cloud Build service account that was created for you by Google. It will look something
 like `<your_project_number>@cloudbuild.gserviceaccount.com`. You can give it only the required permissions for each
 service, or simply give it the `Project Editor` role if you're comfortable with that.
- 3. Clone the GitHub repo and make the necessary changes to `config.yaml`
- 4. Finally, `gcloud builds submit --config=cloudbuild.yaml <path_to_repo>` 
+
+####Option A: Clone and Source control your config
+ 3A. Clone the GitHub repo and make the necessary changes to `config.yaml`  
+ 4A. Finally, `gcloud builds submit --config=cloudbuild.yaml <path_to_repo>`  
+  
+####Option B: Provide config in GCS
+ 3B. Pull the GitHub repo  
+ 4B. Upload your config to GCS `gs://bucket/containing/my/config.yaml`   
+ 5B. Finally, `gcloud builds submit --config=cloudbuild.yaml --substitutions=_ARGS='--configPath=gs://bucket/containing/my/config.yaml' <path_to_repo>`   
+  
 
 ## Any known limitations?
  Complex schemas are not supported e.g. nested records etc. If you have a complex schema, then create an empty table

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,12 @@ task wrapper(type: Wrapper) {
     gradleVersion = "4.10"
 }
 
+run {
+    if (project.hasProperty("appArgs")) {
+        args Eval.me(appArgs)
+    }
+}
+
 repositories {
     mavenCentral()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,10 +12,6 @@ ext {
     gcsVersion="1.52.0"
 }
 
-run {
-    args findProperty("args")
-}
-
 task wrapper(type: Wrapper) {
     gradleVersion = "4.10"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,10 @@ ext {
     gcsVersion="1.52.0"
 }
 
+run {
+    args findProperty("args")
+}
+
 task wrapper(type: Wrapper) {
     gradleVersion = "4.10"
 }

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,9 +1,10 @@
 steps:
 - name: gcr.io/cloud-builders/git
-  args: ['clone', 'https://github.com/polleyg/gcp-dataflow-copy-bigquery.git']
+  args: ['clone', '${_SOURCE_REPO}' ]
 
 - name: gcr.io/cloud-builders/gradle
-  args: ['build', 'run' ,'--args=${_ARGS}']
+  args: ['build', 'run' ,'-PappArgs="${_APP_ARGS}"']
 
 substitutions:
-  _ARGS: '--configPath=config.yaml' # default value
+  _APP_ARGS: '--configPath=config.yaml' # default value
+  _SOURCE_REPO: 'https://github.com/polleyg/gcp-dataflow-copy-bigquery.git' #default value, this allows you to test on your own repo

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,7 @@ steps:
   args: ['clone', 'https://github.com/polleyg/gcp-dataflow-copy-bigquery.git']
 
 - name: gcr.io/cloud-builders/gradle
-  args: ['build', 'run' ,'-Pargs=--configPath=${_CONFIG_PATH}']
+  args: ['build', 'run' ,'--args=${_ARGS}']
 
 substitutions:
-  _CONFIG_PATH: 'config.yaml' # default value
+  _ARGS: '--configPath=config.yaml' # default value

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,4 +3,7 @@ steps:
   args: ['clone', 'https://github.com/polleyg/gcp-dataflow-copy-bigquery.git']
 
 - name: gcr.io/cloud-builders/gradle
-  args: ['build', 'run']
+  args: ['build', 'run' ,'-Pargs=--configPath=${_CONFIG_PATH}']
+
+substitutions:
+  _CONFIG_PATH: 'config.yaml' # default value

--- a/src/main/java/org/polleyg/BQTableCopyPipeline.java
+++ b/src/main/java/org/polleyg/BQTableCopyPipeline.java
@@ -87,6 +87,12 @@ public class BQTableCopyPipeline {
         }
     }
 
+    /**
+     * Use arguments and Config pojo to prepare the DataflowPipelineOptions POJO
+     * @param args application input arguments
+     * @param config Table config parsed from application arguments and file contents
+     * @return DataflowPipelineOptions object ready to be run
+     **/
     private DataflowPipelineOptions getDataflowPipelineOptions(String[] args, Config config) {
         final String[] dataflowArgs = removeConfigPathFromArgs(args);
         PipelineOptionsFactory.register(DataflowPipelineOptions.class);
@@ -101,6 +107,12 @@ public class BQTableCopyPipeline {
         return options;
     }
 
+    /**
+     * Extracts the Config pojo from arguments and file content
+     * @param args application input arguments
+     * @param mapper application object mapper
+     * @return Config pojo for tables to be copied
+     **/
     private Config setConfig(String[] args, ObjectMapper mapper) throws java.io.IOException {
         String configPath = extractConfigPath(args);
         LOG.info("Fetching config from: " + configPath);

--- a/src/main/java/org/polleyg/GCPHelpers.java
+++ b/src/main/java/org/polleyg/GCPHelpers.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -210,15 +211,16 @@ class GCPHelpers {
         Storage gcs = StorageOptions.getDefaultInstance().getService();
 
         //bucketname should be first element in string with format "gs://[BUCKET_NAME]/[OBJECT_NAME]"
-        String[] sections = path.split("/",1);
+        String[] sections = path.split("/");
         if(sections.length < 2){
-            final String errMsg = "GCS Url must be in format 'gs://[BUCKET_NAME]/[OBJECT_NAME]'. Found: " + path;
+            LOG.info(Arrays.toString(sections));
+            final String errMsg = "GCS Url must be in format 'gs://[BUCKET_NAME]/[OBJECT_NAME]'. Found: " + gcsPath;
             LOG.error(errMsg);
             throw new RuntimeException(errMsg);
         }
 
         String bucketName = sections[0]; //get bucketname
-        String srcFilename = String.join("/", ArrayUtils.removeElement(sections, bucketName)); //remove bucketname and rejoin
+        String srcFilename = path.replaceFirst(bucketName + "/", ""); //remove bucketname and rejoin
         String localPath = "/tmp/" + srcFilename;
 
         Blob blob = gcs.get(BlobId.of(bucketName, srcFilename));

--- a/src/main/java/org/polleyg/GCPHelpers.java
+++ b/src/main/java/org/polleyg/GCPHelpers.java
@@ -220,13 +220,16 @@ class GCPHelpers {
         }
 
         String bucketName = sections[0]; //get bucketname
-        String srcFilename = path.replaceFirst(bucketName + "/", ""); //remove bucketname and rejoin
-        String localPath = "/tmp/" + srcFilename;
+        String srcFilePath = path.replaceFirst(bucketName + "/", ""); //remove bucketname and rejoin
+        String srcFilename = sections[sections.length - 1];
 
-        Blob blob = gcs.get(BlobId.of(bucketName, srcFilename));
-        blob.downloadTo(Paths.get(localPath));
+        LOG.info(String.format("Bucketname: %s, srcPath: %s, srcFile: %s",bucketName,srcFilePath,srcFilename));
 
-        return localPath;
+
+        Blob blob = gcs.get(BlobId.of(bucketName, srcFilePath));
+        blob.downloadTo(Paths.get(srcFilename));
+
+        return srcFilename;
 
     }
 

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -1,5 +1,5 @@
 # [required] The GCP project id (not the number). You can find this in the GCP console.
-project: <YOUR_PROJECT_ID>
+project: test_proj
 
 # [required] The type of runner. One of:
 # - dataflow (runs on GCP)
@@ -21,14 +21,14 @@ runner: dataflow
 # [required] target: The target in format [PROJECT]:[DATASET] for dataset or [PROJECT]:[DATASET].[TABLE] for table
 copies:
 # Dataset copy
-- source: bigquery-public-data:world_bank_wdi
-  target: <YOUR_PROJECT_ID>:world_bank_wdi
-  numWorkers: 2
-  maxNumWorkers: 2
+#- source: bigquery-public-data:world_bank_wdi
+#  target: test_proj:world_bank_wdi
+#  numWorkers: 2
+#  maxNumWorkers: 2
 
 # Table copy to EU
 - source: bigquery-public-data:world_bank_wdi.country_series_definitions
-  target: <YOUR_PROJECT_ID>:world_bank_wdi_US.country_series_definitions
+  target: test_proj:world_bank_wdi_US.country_series_definitions
   maxNumWorkers: 1
   workerMachineType: n1-standard-2
   writeDisposition: append
@@ -36,7 +36,7 @@ copies:
 
   # Table copy to US
 - source: bigquery-public-data:world_bank_wdi.country_series_definitions
-  target: <YOUR_PROJECT_ID>:world_bank_wdi_EU.country_series_definitions
+  target: test_proj:world_bank_wdi_EU.country_series_definitions
   maxNumWorkers: 1
   workerMachineType: n1-standard-2
   writeDisposition: append

--- a/src/main/resources/config.yaml
+++ b/src/main/resources/config.yaml
@@ -1,5 +1,5 @@
 # [required] The GCP project id (not the number). You can find this in the GCP console.
-project: test_proj
+project: <YOUR_PROJECT_ID>
 
 # [required] The type of runner. One of:
 # - dataflow (runs on GCP)
@@ -21,14 +21,14 @@ runner: dataflow
 # [required] target: The target in format [PROJECT]:[DATASET] for dataset or [PROJECT]:[DATASET].[TABLE] for table
 copies:
 # Dataset copy
-#- source: bigquery-public-data:world_bank_wdi
-#  target: test_proj:world_bank_wdi
-#  numWorkers: 2
-#  maxNumWorkers: 2
+- source: bigquery-public-data:world_bank_wdi
+  target: <YOUR_PROJECT_ID>:world_bank_wdi
+  numWorkers: 2
+  maxNumWorkers: 2
 
 # Table copy to EU
 - source: bigquery-public-data:world_bank_wdi.country_series_definitions
-  target: test_proj:world_bank_wdi_US.country_series_definitions
+  target: <YOUR_PROJECT_ID>:world_bank_wdi_US.country_series_definitions
   maxNumWorkers: 1
   workerMachineType: n1-standard-2
   writeDisposition: append
@@ -36,7 +36,7 @@ copies:
 
   # Table copy to US
 - source: bigquery-public-data:world_bank_wdi.country_series_definitions
-  target: test_proj:world_bank_wdi_EU.country_series_definitions
+  target: <YOUR_PROJECT_ID>:world_bank_wdi_EU.country_series_definitions
   maxNumWorkers: 1
   workerMachineType: n1-standard-2
   writeDisposition: append


### PR DESCRIPTION
You can upload a file to GCS and pass the file to cloud build as a command line argument in order to execute the copy for different tables without needing to check in your config. 

Also bug fix for creation of datasets. It would previously try create it for every table in a dataset. Now it does it once per copy.